### PR TITLE
Fix broken .bat file.

### DIFF
--- a/batch/depends.bat
+++ b/batch/depends.bat
@@ -1,2 +1,2 @@
 @echo off
-java -jar %~dp0\depends.jar %*
+java -jar %~dp0depends.jar %*

--- a/batch/depends.bat
+++ b/batch/depends.bat
@@ -1,2 +1,2 @@
-exec java -jar depends.jar %*
-
+@echo off
+java -jar %~dp0\depends.jar %*


### PR DESCRIPTION
- turn off echo of command being executed (this is standard for .bat files when you're not debugging them)
- remove exec (exec doesn't exist in .bat land)
- look for .jar file in the same directory as the .bat file `%dp0` expands to the drive and path of the executing .bat file.