### PR TITLE
fix NullPointerException in DependencyGenerator

### DIFF
--- a/src/main/java/depends/generator/DependencyGenerator.java
+++ b/src/main/java/depends/generator/DependencyGenerator.java
@@ -150,6 +150,9 @@ public abstract class DependencyGenerator {
 		Entity fromFile = fromEntity.getAncestorOfType(FileEntity.class);
 		Entity toFile = toEntity.getAncestorOfType(FileEntity.class);
 
+		// If the toEntity is above the file level (e.g. a package), then toFile will be null.
+		if (toFile == null) return null;
+
 		return new DependencyDetail(
 				new LocationInfo(stripper.stripFilename(fromObject),typeOf(fromEntity),stripper.stripFilename(fromFile.getQualifiedName()),fromLineNumber),
 				new LocationInfo(stripper.stripFilename(toObject),typeOf(toEntity),stripper.stripFilename(toFile.getQualifiedName()),toEntity.getLine()));


### PR DESCRIPTION
When using the `--detail` flag, depends will sometimes crash with a NullPointerException. This is caused by an assumption in the `buildDescription` method of the `DependencyGenerator` class that every `toEntity` is at or below the file level. However, sometimes a `toEntity` is above the file level (e.g. a Java package will not have a file ancestor).

I can't promise that this is the only location where this assumption is made.